### PR TITLE
Change false benchmark with conditionnally compiled executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.cabal-sandbox/
+cabal.sandbox.config
+dist/

--- a/demo/Main.hs
+++ b/demo/Main.hs
@@ -1,4 +1,5 @@
--- You can execute this file with 'cabal bench demo'.
+-- In order to run this file, first configure cabal with '-fWithExamples',
+-- then execute 'cabal run demo'.
 {-# LANGUAGE QuasiQuotes, ScopedTypeVariables, OverloadedStrings #-}
 
 import Control.Monad

--- a/hasql.cabal
+++ b/hasql.cabal
@@ -67,6 +67,9 @@ build-type:
 cabal-version:
   >=1.10
 
+flag WithExamples
+    Description: Build examples
+    Default: False
 
 source-repository head
   type:
@@ -120,7 +123,6 @@ library
     base-prelude >= 0.1.3 && < 0.2,
     base >= 4.5 && < 4.8
 
-
 test-suite tests
   type:             
     exitcode-stdio-1.0
@@ -144,12 +146,7 @@ test-suite tests
     base >= 4.5 && < 4.8
 
 
--- Well, it's not a benchmark actually, 
--- but in Cabal there's no better way to specify an executable, 
--- which is not intended for distribution.
-benchmark demo
-  type: 
-    exitcode-stdio-1.0
+executable demo
   hs-source-dirs:
     demo
   main-is:
@@ -166,5 +163,9 @@ benchmark demo
     hasql == 0.2.*,
     transformers >= 0.2 && < 0.5,
     base >= 4.5 && < 4.8
+  if flag(WithExamples)
+    Buildable: True
+  else
+    Buildable: False
 
 

--- a/hasql.cabal
+++ b/hasql.cabal
@@ -158,13 +158,13 @@ executable demo
     -funbox-strict-fields
   default-language:
     Haskell2010
-  build-depends:
-    hasql-postgres == 0.7.*,
-    hasql == 0.2.*,
-    transformers >= 0.2 && < 0.5,
-    base >= 4.5 && < 4.8
   if flag(WithExamples)
     Buildable: True
+    build-depends:
+      hasql-postgres == 0.7.*,
+      hasql == 0.2.*,
+      transformers >= 0.2 && < 0.5,
+      base >= 4.5 && < 4.8
   else
     Buildable: False
 


### PR DESCRIPTION
By using the `buildable` flag in *cabal*, we can distribute the demo without always compiling it