### PR TITLE
add: stack support; update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+.stack-work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.4.1
+* Stack support
+* Update dependencies
+
 # 0.7.3.1
 * Attoparsec-0.13 support
 

--- a/hasql.cabal
+++ b/hasql.cabal
@@ -1,7 +1,7 @@
 name:
   hasql
 version:
-  0.7.4
+  0.7.4.1
 synopsis:
   A minimalistic general high level API for relational databases
 description:
@@ -13,19 +13,19 @@ description:
   * Concise and crisp API. Just a few functions and two monads doing all the
   boilerplate job for you.
   .
-  * A powerful transaction abstraction, which provides 
+  * A powerful transaction abstraction, which provides
   an automated resolution of conflicts.
   The API ensures that you're only able to perform a specific
   set of actions in the transaction context,
-  which allows Hasql to safely resolve conflicting transactions 
+  which allows Hasql to safely resolve conflicting transactions
   by automatically retrying them.
   This is much inspired by STM and ST.
   .
   * Support for cursors. Allows to fetch virtually limitless result sets in a
   constant memory using streaming.
   .
-  * Employment of prepared statements. 
-  Every statement you emit gets prepared and cached. 
+  * Employment of prepared statements.
+  Every statement you emit gets prepared and cached.
   This raises the performance of the backend.
   .
   * Automated management of resources related to connections, transactions and
@@ -49,9 +49,9 @@ description:
 category:
   Database
 homepage:
-  https://github.com/nikita-volkov/hasql 
+  https://github.com/nikita-volkov/hasql
 bug-reports:
-  https://github.com/nikita-volkov/hasql/issues 
+  https://github.com/nikita-volkov/hasql/issues
 author:
   Nikita Volkov <nikita.y.volkov@mail.ru>
 maintainer:
@@ -64,6 +64,9 @@ license-file:
   LICENSE
 build-type:
   Simple
+tested-with:
+  GHC==7.8.4,
+  GHC==7.10.2
 cabal-version:
   >=1.10
 extra-source-files:
@@ -95,34 +98,34 @@ library
   exposed-modules:
     Hasql
   build-depends:
-    -- 
-    resource-pool == 0.2.*,
-    hasql-backend == 0.4.*,
-    -- 
-    template-haskell >= 2.8 && < 2.11,
-    -- 
-    attoparsec >= 0.10 && < 0.14,
-    -- 
-    vector < 0.12,
-    text >= 1.0 && < 1.3,
-    -- 
-    either >= 4.3 && < 5,
-    list-t >= 0.3.1 && < 0.5,
-    mmorph == 1.0.*,
-    mtl >= 2.1 && < 2.3,
-    monad-control >= 0.3 && < 1.1,
-    transformers-base == 0.4.*,
-    transformers >= 0.3 && < 0.5,
-    base-prelude >= 0.1.3 && < 0.2,
-    base >= 4.6 && < 4.9
+    --
+    resource-pool,
+    hasql-backend,
+    --
+    template-haskell >= 2.8,
+    --
+    attoparsec >= 0.10,
+              --
+    vector,
+    text >= 1.0,
+    --
+    either >= 4.3,
+    list-t >= 0.3.1,
+    mmorph,
+    mtl >= 2.1,
+    monad-control >= 0.3,
+    transformers-base,
+    transformers >= 0.3,
+    base-prelude >= 0.1.3,
+    base >= 4.6 && < 5.0
 
 
 test-suite hspec
-  type:             
+  type:
     exitcode-stdio-1.0
-  hs-source-dirs:   
+  hs-source-dirs:
     hspec
-  main-is:          
+  main-is:
     Main.hs
   ghc-options:
     -threaded
@@ -133,15 +136,15 @@ test-suite hspec
   default-language:
     Haskell2010
   build-depends:
-    -- 
+    --
     hasql,
     hasql-backend,
-    -- 
-    hspec == 2.1.*,
-    -- 
+    --
+    hspec,
+    --
     vector,
-    -- 
-    mtl-prelude < 3,
+    --
+    mtl-prelude,
     base-prelude
 
 
@@ -161,27 +164,27 @@ test-suite hspec-postgres
   default-language:
     Haskell2010
   build-depends:
-    -- 
+    --
     hasql,
-    hasql-postgres == 0.10.*,
-    -- 
-    slave-thread == 0.1.*,
-    -- 
-    hspec == 2.1.*,
-    -- 
+    hasql-postgres,
+    --
+    slave-thread,
+    --
+    hspec,
+    --
     text,
-    -- 
+    --
     monad-control,
     either,
-    mtl-prelude < 3,
+    mtl-prelude,
     base-prelude
 
 
--- Well, it's not a benchmark actually, 
--- but in Cabal there's no better way to specify an executable, 
+-- Well, it's not a benchmark actually,
+-- but in Cabal there's no better way to specify an executable,
 -- which is not intended for distribution.
 benchmark demo
-  type: 
+  type:
     exitcode-stdio-1.0
   hs-source-dirs:
     demo
@@ -196,8 +199,6 @@ benchmark demo
     Haskell2010
   build-depends:
     hasql,
-    hasql-postgres == 0.10.*,
-    transformers >= 0.3 && < 0.5,
+    hasql-postgres,
+    transformers >= 0.3,
     base
-
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+# resolver: lts-2.22  # for GHC-7.8
+resolver: lts-3.5


### PR DESCRIPTION
* Removes upper bounds on dependencies
* Adds stack support, defaulting to GHC-7.10
* Tested with: GHC-7.8.4, GHC-7.10.2
* Tested against updated: hasql-backend, hasql-postgresql
* .gitignore for dist, .stack-work

Here's everything working together:

```
allele@parametric:~/dev/hasql:$ stack clean
allele@parametric:~/dev/hasql:$ ls
hasql  hasql-backend  hasql-postgres  stack.yaml
allele@parametric:~/dev/hasql:$ more stack.yaml 
```

```yaml
flags: {}
packages:
- hasql/
- hasql-backend/
- hasql-postgres/
extra-deps:
  - criterion-plus-0.1.3
  - HDBC-2.4.0.1
  - HDBC-postgresql-2.3.2.3
resolver: lts-3.5
```

```
allele@parametric:~/dev/hasql:$ stack build
hasql-0.7.4.1-20792b88031018a947c17120d8d34883: unregistering (missing dependencies: hasql-backend)
hasql-backend-0.4.2.1-9959897ad3289b5d63d117ec27d34e52: unregistering (local file changes)
hasql-postgres-0.10.5.1-18a2f341b426f90a2f04dca5868cd235: unregistering (missing dependencies: hasql-backend)
hasql-backend-0.4.2.1: configure
hasql-backend-0.4.2.1: build
hasql-backend-0.4.2.1: install
hasql-0.7.4.1: configure
hasql-0.7.4.1: build
hasql-postgres-0.10.5.1: configure
hasql-postgres-0.10.5.1: build
hasql-0.7.4.1: install
hasql-postgres-0.10.5.1: install
Completed all 3 actions.
```