### PR TITLE
Add rudimentary tracking of explicit disconnects

### DIFF
--- a/library/Hasql/Commands.hs
+++ b/library/Hasql/Commands.hs
@@ -29,5 +29,3 @@ setEncodersToUTF8 =
 setMinClientMessagesToWarning :: Commands
 setMinClientMessagesToWarning =
   Commands (pure "SET client_min_messages TO WARNING")
-
-

--- a/library/Hasql/Connection/Impl.hs
+++ b/library/Hasql/Connection/Impl.hs
@@ -1,7 +1,10 @@
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+
 module Hasql.Connection.Impl
 where
 
 import Hasql.Prelude
+import Control.Concurrent.MVar (newMVar, swapMVar)
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 import qualified Hasql.PreparedStatementRegistry as PreparedStatementRegistry
 import qualified Hasql.IO as IO
@@ -10,7 +13,7 @@ import qualified Hasql.IO as IO
 -- |
 -- A single connection to the database.
 data Connection =
-  Connection !LibPQ.Connection !Bool !PreparedStatementRegistry.PreparedStatementRegistry
+  Connection !(MVar LibPQ.Connection) !Bool !PreparedStatementRegistry.PreparedStatementRegistry
 
 -- |
 -- Possible details of the connection acquistion error.
@@ -21,17 +24,26 @@ type ConnectionError =
 -- Acquire a connection using the provided settings encoded according to the PostgreSQL format.
 acquire :: ByteString -> IO (Either ConnectionError Connection)
 acquire settings =
-  {-# SCC "acquire" #-} 
+  {-# SCC "acquire" #-}
   runEitherT $ do
     pqConnection <- lift (IO.acquireConnection settings)
     lift (IO.checkConnectionStatus pqConnection) >>= traverse left
     lift (IO.initConnection pqConnection)
     integerDatetimes <- lift (IO.getIntegerDatetimes pqConnection)
     registry <- lift (IO.acquirePreparedStatementRegistry)
-    pure (Connection pqConnection integerDatetimes registry)
+    pqConnectionRef <- lift (newMVar pqConnection)
+    pure (Connection pqConnectionRef integerDatetimes registry)
 
 -- |
 -- Release the connection.
 release :: Connection -> IO ()
-release (Connection pqConnection _ _) =
-  LibPQ.finish pqConnection
+release (Connection pqConnectionRef _ _) =
+  mask_ $ do
+    nullConnection <- LibPQ.newNullConnection
+    pqConnection <- swapMVar pqConnectionRef nullConnection
+    IO.releaseConnection pqConnection
+
+{-# INLINE withConnectionRef #-}
+withConnectionRef :: MVar LibPQ.Connection -> (LibPQ.Connection -> IO a) -> IO a
+withConnectionRef =
+  withMVar


### PR DESCRIPTION
No guarantee that using a connection after it has been closed will
result in a sensible operation,  but at least it won't result in
a use-after-free memory fault now.

Also, this should make this interface relatively safe to use concurrently.