### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/hasql.cabal
+++ b/hasql.cabal
@@ -79,7 +79,7 @@ library
     -- builders:
     bytestring-tree-builder >= 0.2.5 && < 0.3,
     -- data:
-    dlist >= 0.7 && < 0.8,
+    dlist >= 0.7 && < 0.9,
     aeson >= 0.7 && < 0.12,
     uuid == 1.3.*,
     vector >= 0.10 && < 0.12,


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `hasql`, but I don't think it will be break anything.