### PR TITLE
Reversed evaulation order when executing dropRemaining.

### DIFF
--- a/library/Hasql/Private/Decoders/Results.hs
+++ b/library/Hasql/Private/Decoders/Results.hs
@@ -85,7 +85,7 @@ dropRemainders =
         getResultMaybe =
           lift $ LibPQ.getResult connection
         onResult result =
-          checkErrors *> loop integerDatetimes connection
+          loop integerDatetimes connection <* checkErrors
           where
             checkErrors =
               EitherT $ fmap (mapLeft ResultError) $ Result.run Result.unit (integerDatetimes, result)


### PR DESCRIPTION
This fix addresses all instances in which a multi statement sql query is dispatched to the server, and one statement in the middle fails. The prior implementation didn't make the required number of calls to libpq's `getResult` function. Which resulted in the `(Just "another command is already in progress\n")` error on the next SQL call from either `sql` or `query`.

This fix also addresses [hasql-transaction/#6](https://github.com/nikita-volkov/hasql-transaction/issues/6).