### PR TITLE
Allow tasty-quickcheck 0.10

### DIFF
--- a/hasql.cabal
+++ b/hasql.cabal
@@ -124,7 +124,7 @@ test-suite tasty
     hasql,
     -- testing:
     tasty >= 0.12 && < 1.1,
-    tasty-quickcheck >= 0.9 && < 0.10,
+    tasty-quickcheck >= 0.9 && < 0.11,
     tasty-hunit >= 0.9 && < 0.11,
     quickcheck-instances >= 0.3.11 && < 0.4,
     QuickCheck >= 2.8.1 && < 3,


### PR DESCRIPTION
Tests pass with the new test tool.