### PR TITLE
Add convenience function for refining domain types

### DIFF
--- a/library/Hasql/Decoders.hs
+++ b/library/Hasql/Decoders.hs
@@ -47,6 +47,7 @@ module Hasql.Decoders
   hstore,
   enum,
   custom,
+  refine,
   -- * Array
   Array,
   dimension,
@@ -462,6 +463,14 @@ jsonbBytes fn =
 custom :: (Bool -> ByteString -> Either Text a) -> Value a
 custom fn =
   Value (Value.decoderFn fn)
+
+-- |
+-- Maps a custom decoding over an existing 'Value' decoder.
+--
+{-# INLINABLE refine #-}
+refine :: (a -> Either Text b) -> Value a -> Value b
+refine fn (Value v) =
+  Value (Value.Value (ask >>= \b -> lift (A.refine fn (Value.run v b))))
 
 
 -- ** Composite value decoders

--- a/library/Hasql/Private/Prelude.hs
+++ b/library/Hasql/Private/Prelude.hs
@@ -26,7 +26,7 @@ import Control.Monad.Trans.Class as Exports
 import Control.Monad.Trans.Cont as Exports hiding (shift, callCC)
 import Control.Monad.Trans.Except as Exports (ExceptT(ExceptT), Except, except, runExcept, runExceptT, mapExcept, mapExceptT, withExcept, withExceptT, throwE, catchE)
 import Control.Monad.Trans.Maybe as Exports
-import Control.Monad.Trans.Reader as Exports (Reader, runReader, mapReader, withReader, ReaderT(ReaderT), runReaderT, mapReaderT, withReaderT)
+import Control.Monad.Trans.Reader as Exports (Reader, ask, runReader, mapReader, withReader, ReaderT(ReaderT), runReaderT, mapReaderT, withReaderT)
 import Control.Monad.Trans.State.Strict as Exports (State, runState, evalState, execState, mapState, withState, StateT(StateT), runStateT, evalStateT, execStateT, mapStateT, withStateT)
 import Control.Monad.Trans.Writer.Strict as Exports (Writer, runWriter, execWriter, mapWriter, WriterT(..), execWriterT, mapWriterT)
 import Data.Functor.Compose as Exports


### PR DESCRIPTION
This is based off of the corresponding PR to postgresql-binary: https://github.com/nikita-volkov/postgresql-binary/pull/13

For PostgreSQL columns that are restricted domain types, having a simple way to validate the domains without having to propogate Either types into column values would be very convenient.
