### PR TITLE
Support for multiple parameter statements

### DIFF
--- a/hasql.cabal
+++ b/hasql.cabal
@@ -1,7 +1,7 @@
 name:
   hasql
 version:
-  1.3.0.5
+  1.3.0.6
 category:
   Hasql, Database, PostgreSQL
 synopsis:
@@ -96,6 +96,7 @@ library
     -- errors:
     loch-th == 0.2.*,
     placeholders == 0.1.*,
+    extra >= 1.6,
     -- general:
     base-prelude >= 0.1.19 && < 2,
     base >= 4.9 && < 5

--- a/library/Hasql/Session.hs
+++ b/library/Hasql/Session.hs
@@ -3,6 +3,7 @@ module Hasql.Session
   Session,
   sql,
   statement,
+  multiParamStatement,
   -- * Execution
   run,
   -- * Errors

--- a/library/Hasql/Statement.hs
+++ b/library/Hasql/Statement.hs
@@ -53,3 +53,14 @@ instance Profunctor Statement where
   {-# INLINE dimap #-}
   dimap f1 f2 (Statement template encoder decoder preparable) =
     Statement template (contramap f1 encoder) (fmap f2 decoder) preparable
+
+data MultiParamStatement a b =
+  MultiParamStatement ByteString [Encoders.Params a] (Decoders.Result b) Bool
+
+instance Functor (MultiParamStatement a) where
+  {-# INLINE fmap #-}
+  fmap = rmap
+instance Profunctor MultiParamStatement where
+  {-# INLINE dimap #-}
+  dimap f1 f2 (MultiParamStatement template encoders decoder preparable) =
+    MultiParamStatement template (contramap f1 <$> encoders) (fmap f2 decoder) preparable


### PR DESCRIPTION
This pull adds support for statements that need multiple parameters. My use case is fairly specific where I build a number of CTEs and join at the end. Each CTE links to a specific sum type that specifies the parameters for that CTE. It is better than building a query as a string as the dynamic query can be prepared and there is no need to sanitise the values manually to prevent injection.

I may have missed a completely different way of doing this, but if not I hope it is useful.
