### PR TITLE
Deal with removed deprecated ByteString modules

### DIFF
--- a/library/Hasql/Private/Commands.hs
+++ b/library/Hasql/Private/Commands.hs
@@ -9,8 +9,7 @@ where
 
 import Hasql.Private.Prelude
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy.Builder as BB
-import qualified Data.ByteString.Lazy.Builder.ASCII as BB
+import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BL
 
 

--- a/library/Hasql/Private/Settings.hs
+++ b/library/Hasql/Private/Settings.hs
@@ -2,8 +2,7 @@ module Hasql.Private.Settings where
 
 import Hasql.Private.Prelude
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy.Builder as BB
-import qualified Data.ByteString.Lazy.Builder.ASCII as BB
+import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BL
 
 


### PR DESCRIPTION
The ByteString 0.11 package included with GHC 9.2 droppped a few
long deprecated modules and functions.