### PR TITLE
experiment / request for feedback: lazy bytestring variant of 'unknown'

### DIFF
--- a/library/Hasql/Encoders.hs
+++ b/library/Hasql/Encoders.hs
@@ -40,6 +40,8 @@ module Hasql.Encoders
   jsonbBytes,
   enum,
   unknown,
+  unknownLazy,
+  unknown',
   array,
   foldableArray,
   -- * Array

--- a/library/Hasql/Private/Encoders.hs
+++ b/library/Hasql/Private/Encoders.hs
@@ -13,7 +13,7 @@ import qualified Hasql.Private.Encoders.Value as Value
 import qualified Hasql.Private.Encoders.Array as Array
 import qualified Hasql.Private.PTI as PTI
 import qualified Hasql.Private.Prelude as Prelude
-
+import qualified Data.ByteString.Lazy as LBS
 
 -- * Parameters Product Encoder
 -------------------------
@@ -280,6 +280,10 @@ produces an encoder of that value.
 enum :: (a -> Text) -> Value a
 enum mapping = Value (Value.unsafePTI PTI.text (const (A.text_strict . mapping)) (C.text . mapping))
 
+{-# INLINABLE unknown' #-}
+unknown' :: Show a => (a -> A.Encoding) -> Value a
+unknown' enc = Value (Value.unsafePTIWithShow PTI.unknown (const enc))
+
 {-|
 Identifies the value with the PostgreSQL's \"unknown\" type,
 thus leaving it up to Postgres to infer the actual type of the value.
@@ -291,7 +295,11 @@ section of the Postgres' documentation.
 -}
 {-# INLINABLE unknown #-}
 unknown :: Value ByteString
-unknown = Value (Value.unsafePTIWithShow PTI.unknown (const A.bytea_strict))
+unknown = unknown' A.bytea_strict
+
+{-# INLINABLE unknownLazy #-}
+unknownLazy :: Value LBS.ByteString
+unknownLazy = unknown' A.bytea_lazy
 
 {-|
 Lift an array encoder into a parameter encoder.


### PR DESCRIPTION
Postgrest happens to pass a potentially large JSON value from a lazy byte string to hasql via [`unknown`](https://hackage.haskell.org/package/hasql-1.5.0.3/docs/Hasql-Encoders.html#v:unknown). By using `unknownLazy` as introduced by this PR, we can save a copy, reducing memory usage significantly in some scenarios.

Filing this PR mostly to get your input on whether you think whether (something like) `unknownLazy` would be a reasonable addition, and/or you have some other idea how hasql might help here.

(It's entirely possible that we should be making deeper changes on the Postgrest side, this is just scratching the surface, but seems like a potentially nice and easy win.)

Reference: https://github.com/PostgREST/postgrest/pull/2333#issuecomment-1157459458