### PR TITLE
Provide a generic encoding escape hatch

### DIFF
--- a/hasql.cabal
+++ b/hasql.cabal
@@ -88,6 +88,8 @@ test-suite tasty
   build-depends:
     contravariant-extras >=0.3.5.2 && <0.4,
     hasql,
+    postgresql-binary >=0.12.4 && <0.13,
+    postgresql-libpq ==0.9.*,
     QuickCheck >=2.8.1 && <3,
     quickcheck-instances >=0.3.11 && <0.4,
     rerebase <2,

--- a/library/Hasql/Encoders.hs
+++ b/library/Hasql/Encoders.hs
@@ -40,6 +40,7 @@ module Hasql.Encoders
     jsonbBytes,
     enum,
     unknown,
+    value,
     array,
     foldableArray,
 

--- a/library/Hasql/Private/Encoders.hs
+++ b/library/Hasql/Private/Encoders.hs
@@ -252,7 +252,7 @@ enum mapping = Value (Value.unsafePTI PTI.text (const (A.text_strict . mapping))
 -- Identifies the value with the PostgreSQL's \"unknown\" type,
 -- thus leaving it up to Postgres to infer the actual type of the value.
 --
--- The value transimitted is any value encoded in the Postgres' Text data format.
+-- The value transmitted is any value encoded in the Postgres' Text data format.
 -- For reference, see the
 -- <https://www.postgresql.org/docs/10/static/protocol-overview.html#protocol-format-codes Formats and Format Codes>
 -- section of the Postgres' documentation.


### PR DESCRIPTION
As an alternative to #146, this provides a way for users to provide arbitrary custom value encoders, via

```
-- Generic binary encoder, given OIDs and an encoding function.
value :: Show a => LibPQ.Oid -> LibPQ.Oid -> (a -> Binary.Encoding) -> Value a
value oid arrayOid encode = ...
```

Concretely, this addresses the desire within PostgREST to encode JSON directly from a lazy bytestring. The use would be to replace

```
SQL.encoderAndParam (HE.nullable HE.jsonBytes) (LBS.toStrict <$> body)
```

with

```
let jsonBytesLazy = HE.Value (LibPQ.Oid 114) (LibPQ.Oid 199) Binary.bytea_lazy in
  SQL.encoderAndParam (HE.nullable (HE.value jsonBytesLazy) body
```

to avoid a copy.

Supposing the general approach seems acceptable, some things I'm unsure about:
- There's the downside that this exposes implementation details to some extent. Should it be exposed as something like `Hasql.Encoders.Internal` so that it's clear there should be no expectation of stability?
- I'm not at all sure about the naming; also I'd want to document this better (once I know how it ends up).
- To keep things safe in the face of arrays, I chose to make the array OID required, and to fix the format to `Binary`. Both of these could be relaxed, effectively exposing unsafePTIWithShow.
- Is it a good idea to specify OIDs as `LibPQ.Oid`? I went with it because it's already a public type...

