### PR TITLE
Relax lower bound on hashtables

### DIFF
--- a/hasql.cabal
+++ b/hasql.cabal
@@ -65,7 +65,7 @@ library
     contravariant >=1.3 && <2,
     dlist ==0.8.* || >=1 && <2,
     hashable >=1.2 && <2,
-    hashtables >=1.3 && <2,
+    hashtables >=1.1 && <2,
     mtl >=2 && <3,
     network-ip >=0.3.0.3 && <0.4,
     postgresql-binary >=0.13.1 && <0.14,


### PR DESCRIPTION
Prior to 3220655db9ae3f4c86bfb9d248d5f76e4f4275e0 it looks like `hasql` was fine building with `hashtables >= 1.1`; i haven't done a thorough survey of the changes since then, but it appears to work fine with the older version of the library.

My primary motivation for this is supporting `hashable < 1.4`, since it looks like `hasql` itself should work with this version of the library if not for the restriction that `hashtables >= 1.4` imposes upon it.