### PR TITLE
Expose connection from Session

### DIFF
--- a/library/Hasql/Private/Session.hs
+++ b/library/Hasql/Private/Session.hs
@@ -61,3 +61,8 @@ statement input (Statement.Statement template (Encoders.Params paramsEncoder) de
           step (_, _, _, rendering) acc =
             rendering : acc
        in foldr step [] (encoderOp input)
+
+-- |
+-- Returns the connection for the Session
+connection :: Session Connection.Connection
+connection = Session ask

--- a/library/Hasql/Session.hs
+++ b/library/Hasql/Session.hs
@@ -2,6 +2,7 @@ module Hasql.Session
   ( Session,
     sql,
     statement,
+    connection,
 
     -- * Execution
     run,


### PR DESCRIPTION
Closes #85

Hey @nikita-volkov 👋🏼 

Thanks for **hasql**, I really like it! As per the title and linked issue: simple method to expose the current connection in a Session.

My use case happens in conjunction with **hasql-pool**, as there is no `use` method to expose a connection from the pool, and it only accepts a `Session`. That's fine, but given that I need to run some underlying **libpq** functions, this will help me (and hopefully, others) a lot.
