### PR TITLE
Add `hasql-listen-notify` to ecosystem in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Hasql is not just a single library, it is a granular ecosystem of composable lib
 
 * ["hasql-migration"](https://github.com/tvh/hasql-migration) - A port of postgresql-simple-migration for use with hasql.
 
-* ["hasql-notifications"](https://github.com/diogob/hasql-notifications) - Support for PostgreSQL asynchronous notifications.
+* ["hasql-listen-notify"](https://github.com/awkward-squad/hasql-listen-notify) / ["hasql-notifications"](https://github.com/diogob/hasql-notifications) - Support for PostgreSQL asynchronous notifications.
 
 * ["hasql-optparse-applicative"](https://github.com/sannsyn/hasql-optparse-applicative) - "optparse-applicative" parsers for Hasql.
 


### PR DESCRIPTION
Hey! I'd like to add [hasql-listen-notify](https://hackage.haskell.org/package/hasql-listen-notify) to the ecosystem.

I'm not totally sure how to organize the readme. This new library serves the same purpose as the existing [hasql-notifications](https://hackage.haskell.org/package/hasql-notifications), but I wasn't satisfied with that package's interface, so I wrote an alternative.

For now, I just snuck `hasql-listen-notify` in before `hasql-notifications` on the same line, but please feel free to move it or advise where to move it. Thanks.