### PR TITLE
Remove rerebase from the internal library deps

### DIFF
--- a/hasql.cabal
+++ b/hasql.cabal
@@ -151,14 +151,18 @@ library testing-kit
   hs-source-dirs: testing-kit
   exposed-modules:
     Hasql.TestingKit.Constants
+    Hasql.TestingKit.Preludes.Base
     Hasql.TestingKit.Statements.BrokenSyntax
     Hasql.TestingKit.Statements.GenerateSeries
     Hasql.TestingKit.Statements.WrongDecoder
     Hasql.TestingKit.TestingDsl
 
   build-depends:
+    base,
+    bytestring,
     hasql,
-    rerebase <2,
+    transformers,
+    uuid,
 
 test-suite tasty
   import: base

--- a/testing-kit/Hasql/TestingKit/Preludes/Base.hs
+++ b/testing-kit/Hasql/TestingKit/Preludes/Base.hs
@@ -1,0 +1,13 @@
+module Hasql.TestingKit.Preludes.Base
+  ( module Exports,
+  )
+where
+
+import Control.Monad.Trans.Class as Exports
+import Control.Monad.Trans.Except as Exports (Except, ExceptT (ExceptT), catchE, except, finallyE, mapExcept, mapExceptT, runExcept, runExceptT, throwE, withExcept, withExceptT)
+import Data.Bifunctor as Exports
+import Data.ByteString as Exports (ByteString)
+import Data.Functor.Contravariant as Exports
+import Data.Int as Exports
+import Data.UUID as Exports (UUID)
+import Prelude as Exports

--- a/testing-kit/Hasql/TestingKit/Statements/BrokenSyntax.hs
+++ b/testing-kit/Hasql/TestingKit/Statements/BrokenSyntax.hs
@@ -5,7 +5,7 @@ import Hasql.Encoders qualified as Encoders
 import Hasql.Pipeline qualified as Pipeline
 import Hasql.Session qualified as Session
 import Hasql.Statement qualified as Statement
-import Prelude
+import Hasql.TestingKit.Preludes.Base
 
 data Params = Params
   { start :: Int64,

--- a/testing-kit/Hasql/TestingKit/Statements/GenerateSeries.hs
+++ b/testing-kit/Hasql/TestingKit/Statements/GenerateSeries.hs
@@ -5,7 +5,7 @@ import Hasql.Encoders qualified as Encoders
 import Hasql.Pipeline qualified as Pipeline
 import Hasql.Session qualified as Session
 import Hasql.Statement qualified as Statement
-import Prelude
+import Hasql.TestingKit.Preludes.Base
 
 data Params = Params
   { start :: Int64,

--- a/testing-kit/Hasql/TestingKit/Statements/WrongDecoder.hs
+++ b/testing-kit/Hasql/TestingKit/Statements/WrongDecoder.hs
@@ -5,7 +5,7 @@ import Hasql.Encoders qualified as Encoders
 import Hasql.Pipeline qualified as Pipeline
 import Hasql.Session qualified as Session
 import Hasql.Statement qualified as Statement
-import Prelude
+import Hasql.TestingKit.Preludes.Base
 
 data Params = Params
   { start :: Int64,

--- a/testing-kit/Hasql/TestingKit/TestingDsl.hs
+++ b/testing-kit/Hasql/TestingKit/TestingDsl.hs
@@ -24,7 +24,7 @@ import Hasql.Pipeline qualified as Pipeline
 import Hasql.Session qualified as Session
 import Hasql.Statement qualified as Statement
 import Hasql.TestingKit.Constants qualified as Constants
-import Prelude
+import Hasql.TestingKit.Preludes.Base
 
 data Error
   = ConnectionError (Connection.ConnectionError)


### PR DESCRIPTION
As a workaround for Hackage including the dependencies of internal libs in the public list of package dependencies.