### PR TITLE
Make row and column number more explicit in row errors

### DIFF
--- a/library/Hasql/Errors.hs
+++ b/library/Hasql/Errors.hs
@@ -84,7 +84,7 @@ instance Exception SessionError where
               <> maybe "" (\h -> "\n  Hint: " <> BC.unpack h) hint
           UnexpectedResult message -> "Unexpected result: " <> show message
           RowError row column rowError ->
-            "Row error: " <> show row <> ":" <> show column <> " " <> show rowError
+            "Error in row " <> show row <> ", column " <> show column <> ": " <> show rowError
           UnexpectedAmountOfRows amount ->
             "Unexpected amount of rows: " <> show amount
 


### PR DESCRIPTION
In support of https://github.com/nikita-volkov/hasql/issues/142, I've added a more explicit error message for row errors.

I got a row error and didn't even notice it was showing the row and column number until looking at `hasql` source, so it would have saved some time on debugging if it was clearly stated.