### PR TITLE
Add `Hasql.Connection.withConnection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.9.0 (unreleased)
+
+- Add `Hasql.Connection.withConnection`
+
 # 1.8.1
 
 - In case of exceptions thrown by user from inside of Session, the connection status gets checked to be out of transaction and unless it is the connection gets reset.

--- a/library/Hasql/Connection.hs
+++ b/library/Hasql/Connection.hs
@@ -3,6 +3,7 @@
 module Hasql.Connection
   ( Connection,
     ConnectionError,
+    withConnection,
     acquire,
     release,
     Settings,

--- a/library/Hasql/Connection/Core.hs
+++ b/library/Hasql/Connection/Core.hs
@@ -18,6 +18,16 @@ data Connection
 type ConnectionError =
   Maybe ByteString
 
+
+-- |
+-- Acquire a connection and ensure that it is released if an exception is thrown.
+-- For more complicated uses, you probably want the @hasql-pool@ package.
+withConnection :: Settings.Settings -> (Connection -> IO a) -> IO (Either ConnectionError a)
+withConnection settings f = bracket (acquire settings) cleanup $
+  either (pure . Left) (fmap Right . f)
+  where
+    cleanup = either (const $ pure ()) release
+
 -- |
 -- Acquire a connection using the provided settings encoded according to the PostgreSQL format.
 acquire :: Settings.Settings -> IO (Either ConnectionError Connection)


### PR DESCRIPTION
Add a `bracket`-based `withConnection` for the simple cases where one process needs to open and hold a single connection and a connection pool is not appropriate.

(Our internal copy of this uses `MonadUnliftIO` but since everything else here names `IO` explicitly, I thought it would be better to monomorphise the monad used.)