### PR TITLE
Add macaddr encoder and decoder

### DIFF
--- a/library/Hasql/Decoders.hs
+++ b/library/Hasql/Decoders.hs
@@ -45,6 +45,7 @@ module Hasql.Decoders
     interval,
     uuid,
     inet,
+    macaddr,
     json,
     jsonBytes,
     jsonb,

--- a/library/Hasql/Decoders/All.hs
+++ b/library/Hasql/Decoders/All.hs
@@ -259,6 +259,17 @@ inet :: Value Iproute.IPRange
 inet = Value (Value.decoder (const A.inet))
 
 -- |
+-- Decoder of the @MACADDR@ values.
+--
+-- Represented as a 6-tuple of Word8 values in big endian order. If
+-- you use `ip` library consider using it with `fromOctets`.
+--
+-- > (\(a,b,c,d,e,f) -> fromOctets a b c d e f) <$> macaddr
+{-# INLINEABLE macaddr #-}
+macaddr :: Value (Word8, Word8, Word8, Word8, Word8, Word8)
+macaddr = Value (Value.decoder (const A.macaddr))
+
+-- |
 -- Decoder of the @JSON@ values into a JSON AST.
 {-# INLINEABLE json #-}
 json :: Value Aeson.Value

--- a/library/Hasql/Encoders.hs
+++ b/library/Hasql/Encoders.hs
@@ -34,6 +34,7 @@ module Hasql.Encoders
     interval,
     uuid,
     inet,
+    macaddr,
     json,
     jsonBytes,
     jsonLazyBytes,

--- a/library/Hasql/Encoders/All.hs
+++ b/library/Hasql/Encoders/All.hs
@@ -213,6 +213,17 @@ inet :: Value Iproute.IPRange
 inet = Value (Value.unsafePTIWithShow PTI.inet (const A.inet))
 
 -- |
+-- Encoder of @MACADDR@ values.
+--
+-- Represented as a 6-tuple of Word8 values in big endian order. If
+-- you use `ip` library consider using it with `toOctets`.
+--
+-- > toOctets >$< macaddr
+{-# INLINEABLE macaddr #-}
+macaddr :: Value (Word8, Word8, Word8, Word8, Word8, Word8)
+macaddr = Value (Value.unsafePTIWithShow PTI.macaddr (const A.macaddr))
+
+-- |
 -- Encoder of @JSON@ values from JSON AST.
 {-# INLINEABLE json #-}
 json :: Value Aeson.Value


### PR DESCRIPTION
Fix #171 

Requires https://github.com/nikita-volkov/postgresql-binary/pull/25. I didn't write a test for it, I tested locally that it can encode and decode macaddr values.

I went with a simple `Word64` encoding. In my use case I'm using `Net.Mac` from the `ip` package but pulling a second IP address library seemed like an overkill. `iproute`, which Hasql currently uses, has no Mac type.