### PR TITLE
Decouple the Session implementation from Connection

### DIFF
--- a/library/Hasql/Session.hs
+++ b/library/Hasql/Session.hs
@@ -12,5 +12,14 @@ module Hasql.Session
   )
 where
 
+import Hasql.Connection.Core qualified as Connection
 import Hasql.Errors
-import Hasql.Session.Core
+import Hasql.Prelude
+import Hasql.Session.Core hiding (run)
+
+-- |
+-- Execute a sequence of operations with exclusive access to the connection.
+--
+-- Blocks until the connection is available when there is another session running upon the connection.
+run :: Session a -> Connection.Connection -> IO (Either SessionError a)
+run session connection = Connection.use connection session

--- a/library/Hasql/Session/Core.hs
+++ b/library/Hasql/Session/Core.hs
@@ -1,7 +1,5 @@
 module Hasql.Session.Core where
 
-import Control.Monad.State.Class (MonadState (..), gets, modify)
-import Hasql.Connection.Core qualified as Connection
 import Hasql.Contexts.Command qualified as Command
 import Hasql.Contexts.Roundtrip qualified as Roundtrip
 import Hasql.Decoders.All qualified as Decoders
@@ -9,7 +7,6 @@ import Hasql.Decoders.Results qualified as ResultsDecoders
 import Hasql.Encoders.All qualified as Encoders
 import Hasql.Encoders.Params qualified as Encoders.Params
 import Hasql.Errors
-import Hasql.LibPq14 qualified as Pq
 import Hasql.Pipeline.Core qualified as Pipeline
 import Hasql.Prelude
 import Hasql.Statement qualified as Statement
@@ -19,51 +16,37 @@ import Hasql.Structures.StatementCache qualified as StatementCache
 -- |
 -- A batch of actions to be executed in the context of a database connection.
 newtype Session a
-  = Session (StateT ConnectionState.ConnectionState (ExceptT SessionError IO) a)
-  deriving (Functor, Applicative, Monad, MonadError SessionError, MonadIO, MonadState ConnectionState.ConnectionState)
+  = Session (ConnectionState.ConnectionState -> IO (Either SessionError a, ConnectionState.ConnectionState))
+  deriving
+    (Functor, Applicative, Monad, MonadError SessionError, MonadIO)
+    via (ExceptT SessionError (StateT ConnectionState.ConnectionState IO))
 
--- |
--- Executes a bunch of commands on the provided connection.
-run :: Session a -> Connection.Connection -> IO (Either SessionError a)
-run (Session session) (Connection.Connection mvar) =
-  mask $ \restore -> onException (restore main) handler
-  where
-    main = modifyMVar mvar \initialState -> do
-      result <- runExceptT $ runStateT session initialState
-      case result of
-        Left err -> pure (initialState, Left err)
-        Right (a, newState) -> pure (newState, Right a)
-    handler = modifyMVar_ mvar \state -> do
-      let pqConn = ConnectionState.connection state
-      Pq.transactionStatus pqConn >>= \case
-        Pq.TransIdle -> pure state
-        _ -> Pq.reset pqConn >> pure state
+run :: Session a -> ConnectionState.ConnectionState -> IO (Either SessionError a, ConnectionState.ConnectionState)
+run (Session session) connectionState = session connectionState
 
 liftRoundtrip :: (CommandError -> SessionError) -> Roundtrip.Roundtrip a -> Session a
-liftRoundtrip packError roundtrip = Session do
-  pqConnection <- gets ConnectionState.connection
-  result <- liftIO $ join $ Roundtrip.run roundtrip pqConnection
-  either (throwError . packError) pure result
+liftRoundtrip packError roundtrip = Session \connectionState -> do
+  let pqConnection = ConnectionState.connection connectionState
+  result <- join $ Roundtrip.run roundtrip pqConnection
+  case result of
+    Left err -> pure (Left (packError err), connectionState)
+    Right a -> pure (Right a, connectionState)
 
 liftInformedRoundtrip ::
   (CommandError -> SessionError) ->
-  ( Bool ->
-    Bool ->
-    StatementCache.StatementCache ->
-    Roundtrip.Roundtrip (a, StatementCache.StatementCache)
-  ) ->
+  (Bool -> Bool -> StatementCache.StatementCache -> Roundtrip.Roundtrip (a, StatementCache.StatementCache)) ->
   Session a
-liftInformedRoundtrip packError roundtrip = Session do
-  usePreparedStatements <- gets ConnectionState.preparedStatements
-  integerDatetimes <- gets ConnectionState.integerDatetimes
-  statementCache <- gets ConnectionState.statementCache
-  pqConnection <- gets ConnectionState.connection
-  result <- liftIO $ join $ Roundtrip.run (roundtrip usePreparedStatements integerDatetimes statementCache) pqConnection
+liftInformedRoundtrip packError roundtrip = Session \connectionState -> do
+  let usePreparedStatements = ConnectionState.preparedStatements connectionState
+      integerDatetimes = ConnectionState.integerDatetimes connectionState
+      statementCache = ConnectionState.statementCache connectionState
+      pqConnection = ConnectionState.connection connectionState
+  result <- join $ Roundtrip.run (roundtrip usePreparedStatements integerDatetimes statementCache) pqConnection
   case result of
-    Left err -> throwError (packError err)
-    Right (a, newStatementCache) -> do
-      modify \s -> s {ConnectionState.statementCache = newStatementCache}
-      pure a
+    Left err -> pure (Left (packError err), connectionState)
+    Right (a, newStatementCache) ->
+      let newState = connectionState {ConnectionState.statementCache = newStatementCache}
+       in pure (Right a, newState)
 
 liftCommand ::
   (CommandError -> SessionError) ->
@@ -74,23 +57,19 @@ liftCommand packError command =
 
 liftInformedCommand ::
   (CommandError -> SessionError) ->
-  ( Bool ->
-    Bool ->
-    StatementCache.StatementCache ->
-    Command.Command (a, StatementCache.StatementCache)
-  ) ->
+  (Bool -> Bool -> StatementCache.StatementCache -> Command.Command (a, StatementCache.StatementCache)) ->
   Session a
-liftInformedCommand packError command = Session do
-  usePreparedStatements <- gets ConnectionState.preparedStatements
-  integerDatetimes <- gets ConnectionState.integerDatetimes
-  statementCache <- gets ConnectionState.statementCache
-  pqConnection <- gets ConnectionState.connection
-  result <- liftIO $ Command.run (command usePreparedStatements integerDatetimes statementCache) pqConnection
+liftInformedCommand packError command = Session \connectionState -> do
+  let usePreparedStatements = ConnectionState.preparedStatements connectionState
+      integerDatetimes = ConnectionState.integerDatetimes connectionState
+      statementCache = ConnectionState.statementCache connectionState
+      pqConnection = ConnectionState.connection connectionState
+  result <- Command.run (command usePreparedStatements integerDatetimes statementCache) pqConnection
   case result of
-    Left err -> throwError (packError err)
-    Right (a, newStatementCache) -> do
-      modify \s -> s {ConnectionState.statementCache = newStatementCache}
-      pure a
+    Left err -> pure (Left (packError err), connectionState)
+    Right (a, newStatementCache) ->
+      let newState = connectionState {ConnectionState.statementCache = newStatementCache}
+       in pure (Right a, newState)
 
 -- |
 -- Possibly a multi-statement query,
@@ -110,7 +89,7 @@ statement input (Statement.Statement sql (Encoders.Params paramsEncoder) (Decode
       QueryError sql (Encoders.Params.renderReadable paramsEncoder input)
 
     roundtrip usePreparedStatements integerDatetimes registry = do
-      registry <-
+      registry' <-
         if usePreparedStatements && preparable
           then
             let (oidList, valueAndFormatList) = Encoders.Params.compilePreparedStatementData paramsEncoder integerDatetimes input
@@ -122,19 +101,19 @@ statement input (Statement.Statement sql (Encoders.Params paramsEncoder) (Decode
                   pure registry
       result <- ResultsDecoders.toCommand integerDatetimes decoder
       Command.drainResults
-      pure (result, registry)
+      pure (result, registry')
 
 -- |
 -- Execute a pipeline.
 pipeline :: Pipeline.Pipeline result -> Session result
-pipeline pipeline = Session do
-  usePreparedStatements <- gets ConnectionState.preparedStatements
-  integerDatetimes <- gets ConnectionState.integerDatetimes
-  statementCache <- gets ConnectionState.statementCache
-  pqConnection <- gets ConnectionState.connection
-  pipelineResult <- liftIO $ Pipeline.run pipeline usePreparedStatements pqConnection integerDatetimes statementCache
+pipeline pipeline = Session \connectionState -> do
+  let usePreparedStatements = ConnectionState.preparedStatements connectionState
+      integerDatetimes = ConnectionState.integerDatetimes connectionState
+      statementCache = ConnectionState.statementCache connectionState
+      pqConnection = ConnectionState.connection connectionState
+  pipelineResult <- Pipeline.run pipeline usePreparedStatements pqConnection integerDatetimes statementCache
   case pipelineResult of
-    Left err -> throwError err
-    Right (result, newCache) -> do
-      modify \s -> s {ConnectionState.statementCache = newCache}
-      pure result
+    Left err -> pure (Left err, connectionState)
+    Right (result, newCache) ->
+      let newState = connectionState {ConnectionState.statementCache = newCache}
+       in pure (Right result, newState)


### PR DESCRIPTION
This pull request refactors the core execution model of the `Session` monad and its interaction with database connections in the Hasql library. The main change is to move away from using `ReaderT` and `ExceptT` transformer stacks for session execution, instead adopting a state-passing style that explicitly manages the connection state. This enables more direct control over connection state and error handling, and simplifies the API for running sessions.

**Session execution model refactor:**

* The `Session` type is now defined as a function from `ConnectionState.ConnectionState` to `IO (Either SessionError a, ConnectionState.ConnectionState)`, replacing the previous transformer stack (`ReaderT`/`ExceptT`). This makes state transitions explicit and improves composability.
* The `run` function for `Session` is redefined to work with the new state-passing model, both in `Hasql.Session.Core` and as a user-facing API in `Hasql.Session`. [[1]](diffhunk://#diff-0272551e64039bdfc1222999f5b176a1ef8f7a10951e67b3c8361a22c619348aL21-R49) [[2]](diffhunk://#diff-68f80217808f2cddb9878509c48b74b944199e4d9e37455a73154d395251db68R15-R25)

**Connection usage and exclusivity:**

* The `use` function in `Hasql.Connection.Core` is rewritten to accept a `Session` and ensure exclusive access to the connection, blocking if another session is running. A helper `useConnectionState` is introduced for lower-level state access.

**Lifting and running commands/roundtrips:**

* All functions that lift roundtrips, commands, and pipelines into the `Session` monad are rewritten to use the new state-passing style, updating how errors and state transitions are handled. [[1]](diffhunk://#diff-0272551e64039bdfc1222999f5b176a1ef8f7a10951e67b3c8361a22c619348aL21-R49) [[2]](diffhunk://#diff-0272551e64039bdfc1222999f5b176a1ef8f7a10951e67b3c8361a22c619348aL81-R72) [[3]](diffhunk://#diff-0272551e64039bdfc1222999f5b176a1ef8f7a10951e67b3c8361a22c619348aL133-R119)

**Code cleanup and import adjustments:**

* Unused imports related to the old transformer stack are removed, and necessary imports for the new approach are added. [[1]](diffhunk://#diff-49f36af4407aadc115e19e77697d29c70bde6155df819508f4dfe26752b5a75aR7-R11) [[2]](diffhunk://#diff-0272551e64039bdfc1222999f5b176a1ef8f7a10951e67b3c8361a22c619348aL3-L11)

These changes modernize the session execution flow, improve state management, and pave the way for further enhancements in connection handling and error reporting.