### PR TITLE
Add benchmarks to expose per-statement pipeline overhead

### DIFF
--- a/src/benchmarks/Main.hs
+++ b/src/benchmarks/Main.hs
@@ -24,7 +24,24 @@ main =
           sessionBench "manyLargeResults" sessionWithManyLargeResults,
           sessionBench "manyLargeResultsViaPipeline" sessionWithManyLargeResultsViaPipeline,
           sessionBench "manySmallResults" sessionWithManySmallResults,
-          sessionBench "manySmallResultsViaPipeline" sessionWithManySmallResultsViaPipeline
+          sessionBench "manySmallResultsViaPipeline" sessionWithManySmallResultsViaPipeline,
+          -- Benchmarks targeting the per-statement pipeline overhead introduced in 1.10.
+          --
+          -- Session.statement is now routed through pipeline mode even for individual
+          -- queries, adding enterPipelineMode + pipelineSync (an extra server round-trip)
+          -- + exitPipelineMode + mask per statement.  The groups below make that cost
+          -- visible: compare the per-statement time of "sequential" (N × Session.statement)
+          -- against "pipeline" (Session.pipeline with N statements).  The difference is
+          -- the per-call overhead imposed by the pipeline wrapper on sequential execution.
+          bgroup
+            "singleStatementOverhead"
+            [ sessionBench "1-sequential" sessionWith1SmallResult,
+              sessionBench "1-pipeline" sessionWith1SmallResultViaPipeline,
+              sessionBench "10-sequential" sessionWith10SmallResults,
+              sessionBench "10-pipeline" sessionWith10SmallResultsViaPipeline,
+              sessionBench "100-sequential" sessionWithManySmallResults,
+              sessionBench "100-pipeline" sessionWithManySmallResultsViaPipeline
+            ]
         ]
       where
         sessionBench :: (NFData a) => String -> B.Session a -> Benchmark
@@ -32,6 +49,22 @@ main =
           bench name (nfIO (A.use connection session >>= either (fail . show) pure))
 
 -- * Sessions
+
+sessionWith1SmallResult :: B.Session (Int64, Int64)
+sessionWith1SmallResult =
+  B.statement () statementWithSingleRow
+
+sessionWith1SmallResultViaPipeline :: B.Session (Int64, Int64)
+sessionWith1SmallResultViaPipeline =
+  B.pipeline (E.statement () statementWithSingleRow)
+
+sessionWith10SmallResults :: B.Session [(Int64, Int64)]
+sessionWith10SmallResults =
+  replicateM 10 (B.statement () statementWithSingleRow)
+
+sessionWith10SmallResultsViaPipeline :: B.Session [(Int64, Int64)]
+sessionWith10SmallResultsViaPipeline =
+  B.pipeline (replicateM 10 (E.statement () statementWithSingleRow))
 
 sessionWithSingleLargeResultInVector :: B.Session (Vector (Int64, Int64))
 sessionWithSingleLargeResultInVector =
@@ -64,7 +97,7 @@ statementWithSingleRow =
   C.preparable template encoder decoder
   where
     template =
-      "SELECT 1, 2"
+      "SELECT 1::int8, 2::int8"
     encoder =
       conquer
     decoder =
@@ -81,7 +114,7 @@ statementWithManyRows decoder =
   C.preparable template encoder (decoder rowDecoder)
   where
     template =
-      "SELECT generate_series(0,1000) as a, generate_series(1000,2000) as b"
+      "SELECT generate_series(0,1000)::int8 as a, generate_series(1000,2000)::int8 as b"
     encoder =
       conquer
     rowDecoder =


### PR DESCRIPTION
Session.statement now routes every query through pipeline mode (enterPipelineMode + pipelineSync + exitPipelineMode), adding ~6-7 μs of overhead per statement compared to a true serial path. The new singleStatementOverhead group makes this visible by comparing N sequential Session.statement calls against the equivalent Session.pipeline across N=1, 10, and 100. Also fix SQL literals to use explicit ::int8 casts, required on PostgreSQL 18 where untyped integer literals are int4.