### PR TITLE
Handle aborted pipeline during interruption cleanup

### DIFF
--- a/src/comms-tests/Hasql/Comms/Session/CleanUpAfterInterruptionSpec.hs
+++ b/src/comms-tests/Hasql/Comms/Session/CleanUpAfterInterruptionSpec.hs
@@ -27,6 +27,37 @@ spec = do
         status <- Pq.pipelineStatus connection
         status `shouldBe` Pq.PipelineOff
 
+    it "cleans up when pipeline mode is aborted before a sync point" \config -> do
+      withConnection config \connection -> do
+        success <- Pq.enterPipelineMode connection
+        success `shouldBe` True
+
+        sent <- Pq.sendQueryParams connection "SELECT * FROM nonexistent_table" [] Pq.Text
+        sent `shouldBe` True
+        flushRequestSent <- Pq.sendFlushRequest connection
+        flushRequestSent `shouldBe` True
+        flushStatus <- Pq.flush connection
+        flushStatus `shouldBe` Pq.FlushOk
+
+        let waitForResult = do
+              consumed <- Pq.consumeInput connection
+              consumed `shouldBe` True
+              busy <- Pq.isBusy connection
+              if busy
+                then threadDelay 1000 >> waitForResult
+                else Pq.getResult connection
+
+        result <- waitForResult
+        resultStatus <- traverse Pq.resultStatus result
+        resultStatus `shouldBe` Just Pq.FatalError
+        pipelineStatus <- Pq.pipelineStatus connection
+        pipelineStatus `shouldBe` Pq.PipelineAborted
+
+        cleanupResult <- Session.toHandler Session.cleanUpAfterInterruption connection
+        cleanupResult `shouldBe` Right ()
+        finalPipelineStatus <- Pq.pipelineStatus connection
+        finalPipelineStatus `shouldBe` Pq.PipelineOff
+
     it "cleans up when in an open transaction" \config -> do
       withConnection config \connection -> do
         -- Start a transaction

--- a/src/comms-tests/Hasql/Comms/Session/CleanUpAfterInterruptionSpec.hs
+++ b/src/comms-tests/Hasql/Comms/Session/CleanUpAfterInterruptionSpec.hs
@@ -39,15 +39,17 @@ spec = do
         flushStatus <- Pq.flush connection
         flushStatus `shouldBe` Pq.FlushOk
 
-        let waitForResult = do
+        let waitForResult attempts = do
+              when (attempts <= 0) do
+                expectationFailure "Timed out waiting for libpq result after flushing pipeline query"
               consumed <- Pq.consumeInput connection
               consumed `shouldBe` True
               busy <- Pq.isBusy connection
               if busy
-                then threadDelay 1000 >> waitForResult
+                then threadDelay 1000 >> waitForResult (attempts - 1)
                 else Pq.getResult connection
 
-        result <- waitForResult
+        result <- waitForResult (10000 :: Int)
         resultStatus <- traverse Pq.resultStatus result
         resultStatus `shouldBe` Just Pq.FatalError
         pipelineStatus <- Pq.pipelineStatus connection

--- a/src/library/Hasql/Comms/Session.hs
+++ b/src/library/Hasql/Comms/Session.hs
@@ -75,7 +75,9 @@ bringTransactionStatusToIdle = do
 leavePipeline :: Session ()
 leavePipeline = do
   pipelineStatus <- getPipelineStatus
-  when (pipelineStatus == Pq.PipelineOn) do
+  -- PipelineAborted is still pipeline mode. It must reach a sync point before
+  -- libpq permits serial queries such as ABORT or DEALLOCATE ALL again.
+  when (pipelineStatus /= Pq.PipelineOff) do
     -- In pipeline mode, we need to ensure the pipeline is synchronized before exiting.
     -- Send a pipeline sync marker to flush any pending operations.
     syncSuccess <- sendPipelineSync


### PR DESCRIPTION
## What changed

Treat every pipeline status other than `PipelineOff` as requiring pipeline cleanup, including `PipelineAborted`.

The regression test enters pipeline mode, triggers a server error before a sync point, verifies that libpq reports `PipelineAborted`, and then verifies that `cleanUpAfterInterruption` returns the connection to `PipelineOff`.

## Why

`PipelineAborted` still means that libpq is in pipeline mode. The existing `PipelineOn` equality check skips `leavePipeline` in that state. Cleanup then attempts serial commands such as `ABORT` or `DEALLOCATE ALL`, which libpq rejects with `PQsendQuery not allowed in pipeline mode`.

This is a follow-up to #290: that change added synchronization and flushing before leaving a pipeline, but the cleanup path still did not enter that logic for `PipelineAborted`.

## Validation

```text
postgres:9  - passed
postgres:18 - passed
2 examples, 0 failures
```

Command:

```sh
cabal test --enable-tests comms-tests --test-show-details=direct \
  --test-option='--match' \
  --test-option='cleans up when pipeline mode is aborted before a sync point'
```
