### PR TITLE
Port pqi/native's decode-loop redesign onto master

### DIFF
--- a/src/library/Hasql/Comms/ResultDecoder.hs
+++ b/src/library/Hasql/Comms/ResultDecoder.hs
@@ -137,13 +137,14 @@ refine :: (a -> Either Text b) -> ResultDecoder a -> ResultDecoder b
 refine refiner (ResultDecoder plan) = ResultDecoder (Refine refiner plan)
 
 -- * Interpreter
+
 --
 -- 'runPlan' and its helpers are all 'INLINABLE' so GHC can specialize them
 -- at each call site in 'Hasql.Comms.Recv', eliminating the dictionary
 -- dispatch that the old 'ReaderT'\/'ExceptT'-derived 'ResultDecoder' paid
 -- for on every accessor call.
 
-{-# INLINABLE runPlan #-}
+{-# INLINEABLE runPlan #-}
 runPlan :: Plan a -> Pq.Result -> IO (Either Error a)
 runPlan plan result = case plan of
   CheckExecStatus expected -> checkStatus expected result
@@ -204,7 +205,7 @@ runPlan plan result = case plan of
 
 -- | Check exec status and OID compatibility, then hand the row count (as an
 -- 'Int') to the continuation. Shared by every row-consuming plan variant.
-{-# INLINABLE withRows #-}
+{-# INLINEABLE withRows #-}
 withRows ::
   [Pq.ExecStatus] ->
   RowDecoder.RowDecoder a ->
@@ -223,7 +224,7 @@ withRows expectedStatus rowDec result k = do
           maxRows <- rowToInt <$> Pq.ntuples result
           k maxRows
 
-{-# INLINABLE checkStatus #-}
+{-# INLINEABLE checkStatus #-}
 checkStatus :: [Pq.ExecStatus] -> Pq.Result -> IO (Either Error ())
 checkStatus expectedList result = do
   status <- Pq.resultStatus result
@@ -242,7 +243,7 @@ checkStatus expectedList result = do
               )
           )
 
-{-# INLINABLE readServerError #-}
+{-# INLINEABLE readServerError #-}
 readServerError :: Pq.Result -> IO Error
 readServerError result = do
   code <-
@@ -264,7 +265,7 @@ readServerError result = do
           Right pos' -> Prelude.Just pos'
           _ -> Prelude.Nothing
 
-{-# INLINABLE readAffectedRows #-}
+{-# INLINEABLE readAffectedRows #-}
 readAffectedRows :: Pq.Result -> IO (Either Error Int64)
 readAffectedRows result =
   cmdTuplesReader <$> Pq.cmdTuples result
@@ -289,7 +290,7 @@ readAffectedRows result =
                 bytes
             )
 
-{-# INLINABLE readColumnOids #-}
+{-# INLINEABLE readColumnOids #-}
 readColumnOids :: Pq.Result -> IO [Pq.Oid]
 readColumnOids result = do
   columnsAmount <- Pq.nfields result
@@ -297,7 +298,7 @@ readColumnOids result = do
   forM [0 .. count - 1] \colIndex ->
     Pq.ftype result (Pq.Col colIndex)
 
-{-# INLINABLE checkCompatibility #-}
+{-# INLINEABLE checkCompatibility #-}
 checkCompatibility :: RowDecoder.RowDecoder a -> Pq.Result -> IO (Either Error ())
 checkCompatibility rowDec result =
   let oids = RowDecoder.toExpectedOids rowDec
@@ -323,7 +324,7 @@ checkCompatibility rowDec result =
              in go oids 0
           else pure (Left (UnexpectedColumnCount (length oids) (Pq.colToInt maxCols)))
 
-{-# INLINABLE decodeRow #-}
+{-# INLINEABLE decodeRow #-}
 decodeRow :: RowDecoder.RowDecoder a -> Pq.Result -> Pq.Row -> IO (Either Error a)
 decodeRow rowDec result row =
   RowDecoder.toDecoder rowDec result row

--- a/src/library/Hasql/Comms/ResultDecoder.hs
+++ b/src/library/Hasql/Comms/ResultDecoder.hs
@@ -41,12 +41,32 @@ import Hasql.Platform.Prelude hiding (foldl, foldr, maybe)
 import Hasql.Platform.Prelude qualified as Prelude
 import Hasql.Pq qualified as Pq
 
+-- | Defunctionalized plan for consuming a single result from the server.
+--
+-- Each higher-level decoder ('maybe', 'single', 'vector', 'foldl', 'foldr')
+-- is its own constructor rather than a value built out of smaller monadic
+-- actions, so 'runPlan' can interpret it with one direct-'IO' case analysis
+-- per result instead of running generic 'Applicative'\/'Monad' machinery at
+-- every step.
+data Plan a where
+  CheckExecStatus :: [Pq.ExecStatus] -> Plan ()
+  RowsAffected :: Plan Int64
+  ColumnOids :: Plan [Pq.Oid]
+  MaybeRow :: RowDecoder.RowDecoder a -> Plan (Prelude.Maybe a)
+  SingleRow :: RowDecoder.RowDecoder a -> Plan a
+  VectorRows :: RowDecoder.RowDecoder a -> Plan (Vector a)
+  FoldlRows :: (a -> b -> a) -> a -> RowDecoder.RowDecoder b -> Plan a
+  FoldrRows :: (b -> a -> a) -> a -> RowDecoder.RowDecoder b -> Plan a
+  Refine :: (a -> Either Text b) -> Plan a -> Plan b
+  Custom :: (Pq.Result -> IO (Either Error a)) -> Plan a
+
 -- | Result consumption context, for consuming a single result from a sequence of results returned by the server.
 newtype ResultDecoder a
-  = ResultDecoder (Pq.Result -> IO (Either Error a))
-  deriving
-    (Functor, Applicative, Monad, MonadError Error, MonadReader Pq.Result)
-    via (ReaderT Pq.Result (ExceptT Error IO))
+  = ResultDecoder (Plan a)
+
+instance Functor ResultDecoder where
+  {-# INLINE fmap #-}
+  fmap f (ResultDecoder plan) = ResultDecoder (Refine (Right . f) plan)
 
 instance Filterable ResultDecoder where
   {-# INLINE mapMaybe #-}
@@ -60,12 +80,11 @@ instance Filterable ResultDecoder where
 type Handler a = Pq.Result -> IO (Either Error a)
 
 toHandler :: ResultDecoder a -> Handler a
-toHandler (ResultDecoder handler) =
-  handler
+toHandler (ResultDecoder plan) = runPlan plan
 
 fromHandler :: Handler a -> ResultDecoder a
 fromHandler handler =
-  ResultDecoder handler
+  ResultDecoder (Custom handler)
 
 -- * Construction
 
@@ -77,12 +96,178 @@ ok = checkExecStatus [Pq.CommandOk, Pq.TuplesOk]
 pipelineSync :: ResultDecoder ()
 pipelineSync = checkExecStatus [Pq.PipelineSync]
 
+{-# INLINE checkExecStatus #-}
+checkExecStatus :: [Pq.ExecStatus] -> ResultDecoder ()
+checkExecStatus expected = ResultDecoder (CheckExecStatus expected)
+
 {-# INLINE rowsAffected #-}
 rowsAffected :: ResultDecoder Int64
-rowsAffected = do
-  checkExecStatus [Pq.CommandOk]
-  ResultDecoder \result -> do
-    cmdTuplesReader <$> Pq.cmdTuples result
+rowsAffected = ResultDecoder RowsAffected
+
+-- | Get the OIDs of all columns in the current result.
+{-# INLINE columnOids #-}
+columnOids :: ResultDecoder [Pq.Oid]
+columnOids = ResultDecoder ColumnOids
+
+-- * Higher-level decoders
+
+{-# INLINE maybe #-}
+maybe :: RowDecoder.RowDecoder a -> ResultDecoder (Prelude.Maybe a)
+maybe rowDec = ResultDecoder (MaybeRow rowDec)
+
+{-# INLINE single #-}
+single :: RowDecoder.RowDecoder a -> ResultDecoder a
+single rowDec = ResultDecoder (SingleRow rowDec)
+
+{-# INLINE vector #-}
+vector :: RowDecoder.RowDecoder a -> ResultDecoder (Vector a)
+vector rowDec = ResultDecoder (VectorRows rowDec)
+
+{-# INLINE foldl #-}
+foldl :: (a -> b -> a) -> a -> RowDecoder.RowDecoder b -> ResultDecoder a
+foldl step init0 rowDec = ResultDecoder (FoldlRows step init0 rowDec)
+
+{-# INLINE foldr #-}
+foldr :: (b -> a -> a) -> a -> RowDecoder.RowDecoder b -> ResultDecoder a
+foldr step init0 rowDec = ResultDecoder (FoldrRows step init0 rowDec)
+
+-- * Refinement
+
+refine :: (a -> Either Text b) -> ResultDecoder a -> ResultDecoder b
+refine refiner (ResultDecoder plan) = ResultDecoder (Refine refiner plan)
+
+-- * Interpreter
+--
+-- 'runPlan' and its helpers are all 'INLINABLE' so GHC can specialize them
+-- at each call site in 'Hasql.Comms.Recv', eliminating the dictionary
+-- dispatch that the old 'ReaderT'\/'ExceptT'-derived 'ResultDecoder' paid
+-- for on every accessor call.
+
+{-# INLINABLE runPlan #-}
+runPlan :: Plan a -> Pq.Result -> IO (Either Error a)
+runPlan plan result = case plan of
+  CheckExecStatus expected -> checkStatus expected result
+  RowsAffected -> do
+    statusResult <- checkStatus [Pq.CommandOk] result
+    case statusResult of
+      Left err -> pure (Left err)
+      Right () -> readAffectedRows result
+  ColumnOids -> Right <$> readColumnOids result
+  MaybeRow rowDec -> withRows [Pq.TuplesOk] rowDec result \maxRows ->
+    case maxRows of
+      0 -> pure (Right Prelude.Nothing)
+      1 -> fmap (fmap Prelude.Just) (decodeRow rowDec result (intToRow 0))
+      _ -> pure (Left (UnexpectedRowCount maxRows))
+  SingleRow rowDec -> withRows [Pq.TuplesOk] rowDec result \maxRows ->
+    case maxRows of
+      1 -> decodeRow rowDec result (intToRow 0)
+      _ -> pure (Left (UnexpectedRowCount maxRows))
+  VectorRows rowDec -> withRows [Pq.TuplesOk] rowDec result \maxRows -> do
+    mvector <- MutableVector.unsafeNew maxRows
+    failureRef <- newIORef Prelude.Nothing
+    forMFromZero_ maxRows \rowIndex -> do
+      rowResult <- decodeRow rowDec result (intToRow rowIndex)
+      case rowResult of
+        Left !err -> writeIORef failureRef (Prelude.Just err)
+        Right !x -> MutableVector.unsafeWrite mvector rowIndex x
+    readIORef failureRef >>= \case
+      Prelude.Nothing -> Right <$> Vector.unsafeFreeze mvector
+      Prelude.Just err -> pure (Left err)
+  FoldlRows step init0 rowDec -> withRows [Pq.TuplesOk] rowDec result \maxRows -> do
+    accRef <- newIORef init0
+    failureRef <- newIORef Prelude.Nothing
+    forMFromZero_ maxRows \rowIndex -> do
+      rowResult <- decodeRow rowDec result (intToRow rowIndex)
+      case rowResult of
+        Left !err -> writeIORef failureRef (Prelude.Just err)
+        Right !x -> modifyIORef' accRef (\acc -> step acc x)
+    readIORef failureRef >>= \case
+      Prelude.Nothing -> Right <$> readIORef accRef
+      Prelude.Just err -> pure (Left err)
+  FoldrRows step init0 rowDec -> withRows [Pq.TuplesOk] rowDec result \maxRows -> do
+    accRef <- newIORef init0
+    failureRef <- newIORef Prelude.Nothing
+    forMToZero_ maxRows \rowIndex -> do
+      rowResult <- decodeRow rowDec result (intToRow rowIndex)
+      case rowResult of
+        Left !err -> writeIORef failureRef (Prelude.Just err)
+        Right !x -> modifyIORef accRef (\acc -> step x acc)
+    readIORef failureRef >>= \case
+      Prelude.Nothing -> Right <$> readIORef accRef
+      Prelude.Just err -> pure (Left err)
+  Refine refiner inner -> do
+    innerResult <- runPlan inner result
+    pure case innerResult of
+      Left err -> Left err
+      Right a -> first UnexpectedResult (refiner a)
+  Custom handler -> handler result
+
+-- | Check exec status and OID compatibility, then hand the row count (as an
+-- 'Int') to the continuation. Shared by every row-consuming plan variant.
+{-# INLINABLE withRows #-}
+withRows ::
+  [Pq.ExecStatus] ->
+  RowDecoder.RowDecoder a ->
+  Pq.Result ->
+  (Int -> IO (Either Error b)) ->
+  IO (Either Error b)
+withRows expectedStatus rowDec result k = do
+  statusResult <- checkStatus expectedStatus result
+  case statusResult of
+    Left err -> pure (Left err)
+    Right () -> do
+      compatResult <- checkCompatibility rowDec result
+      case compatResult of
+        Left err -> pure (Left err)
+        Right () -> do
+          maxRows <- rowToInt <$> Pq.ntuples result
+          k maxRows
+
+{-# INLINABLE checkStatus #-}
+checkStatus :: [Pq.ExecStatus] -> Pq.Result -> IO (Either Error ())
+checkStatus expectedList result = do
+  status <- Pq.resultStatus result
+  if elem status expectedList
+    then pure (Right ())
+    else case status of
+      Pq.BadResponse -> Left <$> readServerError result
+      Pq.NonfatalError -> Left <$> readServerError result
+      Pq.FatalError -> Left <$> readServerError result
+      Pq.EmptyQuery -> pure (Right ())
+      _ ->
+        pure
+          ( Left
+              ( UnexpectedResult
+                  ("Unexpected result status: " <> fromString (show status) <> ". Expecting one of the following: " <> fromString (show expectedList))
+              )
+          )
+
+{-# INLINABLE readServerError #-}
+readServerError :: Pq.Result -> IO Error
+readServerError result = do
+  code <-
+    fold <$> Pq.resultErrorField result Pq.DiagSqlstate
+  message <-
+    fold <$> Pq.resultErrorField result Pq.DiagMessagePrimary
+  detail <-
+    Pq.resultErrorField result Pq.DiagMessageDetail
+  hint <-
+    Pq.resultErrorField result Pq.DiagMessageHint
+  position <-
+    parsePosition <$> Pq.resultErrorField result Pq.DiagStatementPosition
+  pure (ServerError code message detail hint position)
+  where
+    parsePosition = \case
+      Prelude.Nothing -> Prelude.Nothing
+      Prelude.Just pos ->
+        case Attoparsec.parseOnly (Attoparsec.decimal <* Attoparsec.endOfInput) pos of
+          Right pos' -> Prelude.Just pos'
+          _ -> Prelude.Nothing
+
+{-# INLINABLE readAffectedRows #-}
+readAffectedRows :: Pq.Result -> IO (Either Error Int64)
+readAffectedRows result =
+  cmdTuplesReader <$> Pq.cmdTuples result
   where
     cmdTuplesReader =
       notNothing >=> notEmpty >=> decimal
@@ -104,68 +289,25 @@ rowsAffected = do
                 bytes
             )
 
-{-# INLINE checkExecStatus #-}
-checkExecStatus :: [Pq.ExecStatus] -> ResultDecoder ()
-checkExecStatus expectedList = do
-  status <- ResultDecoder \result -> Right <$> Pq.resultStatus result
-  unless (elem status expectedList) $ do
-    case status of
-      Pq.BadResponse -> serverError
-      Pq.NonfatalError -> serverError
-      Pq.FatalError -> serverError
-      Pq.EmptyQuery -> return ()
-      _ ->
-        throwError
-          ( UnexpectedResult
-              ("Unexpected result status: " <> fromString (show status) <> ". Expecting one of the following: " <> fromString (show expectedList))
-          )
-
-{-# INLINE serverError #-}
-serverError :: ResultDecoder ()
-serverError =
-  ResultDecoder \result -> do
-    code <-
-      fold <$> Pq.resultErrorField result Pq.DiagSqlstate
-    message <-
-      fold <$> Pq.resultErrorField result Pq.DiagMessagePrimary
-    detail <-
-      Pq.resultErrorField result Pq.DiagMessageDetail
-    hint <-
-      Pq.resultErrorField result Pq.DiagMessageHint
-    position <-
-      parsePosition <$> Pq.resultErrorField result Pq.DiagStatementPosition
-    pure $ Left $ ServerError code message detail hint position
-  where
-    parsePosition = \case
-      Nothing -> Nothing
-      Just pos ->
-        case Attoparsec.parseOnly (Attoparsec.decimal <* Attoparsec.endOfInput) pos of
-          Right pos -> Just pos
-          _ -> Nothing
-
--- | Get the OIDs of all columns in the current result.
-{-# INLINE columnOids #-}
-columnOids :: ResultDecoder [Pq.Oid]
-columnOids = ResultDecoder \result -> do
+{-# INLINABLE readColumnOids #-}
+readColumnOids :: Pq.Result -> IO [Pq.Oid]
+readColumnOids result = do
   columnsAmount <- Pq.nfields result
   let Pq.Col count = columnsAmount
-  oids <- forM [0 .. count - 1] $ \colIndex ->
+  forM [0 .. count - 1] \colIndex ->
     Pq.ftype result (Pq.Col colIndex)
-  pure (Right oids)
 
--- * Higher-level decoders
-
-{-# INLINE checkCompatibility #-}
-checkCompatibility :: RowDecoder.RowDecoder a -> ResultDecoder ()
-checkCompatibility rowDec =
+{-# INLINABLE checkCompatibility #-}
+checkCompatibility :: RowDecoder.RowDecoder a -> Pq.Result -> IO (Either Error ())
+checkCompatibility rowDec result =
   let oids = RowDecoder.toExpectedOids rowDec
-   in ResultDecoder \result -> do
+   in do
         maxCols <- Pq.nfields result
         if length oids == Pq.colToInt maxCols
           then
             let go [] _ = pure (Right ())
-                go (Nothing : rest) colIndex = go rest (succ colIndex)
-                go (Just expectedOid : rest) colIndex = do
+                go (Prelude.Nothing : rest) colIndex = go rest (succ colIndex)
+                go (Prelude.Just expectedOid : rest) colIndex = do
                   actualOid <- Pq.ftype result (Pq.toColumn colIndex)
                   if actualOid == expectedOid
                     then go rest (succ colIndex)
@@ -181,131 +323,19 @@ checkCompatibility rowDec =
              in go oids 0
           else pure (Left (UnexpectedColumnCount (length oids) (Pq.colToInt maxCols)))
 
-{-# INLINE maybe #-}
-maybe :: RowDecoder.RowDecoder a -> ResultDecoder (Maybe a)
-maybe rowDec =
-  do
-    checkExecStatus [Pq.TuplesOk]
-    checkCompatibility rowDec
-    ResultDecoder
-      $ \result -> do
-        maxRows <- Pq.ntuples result
-        case maxRows of
-          0 -> return (Right Nothing)
-          1 -> do
-            result <-
-              RowDecoder.toDecoder rowDec result 0
-                <&> first (RowError 0)
-            pure (fmap Just result)
-          _ -> return (Left (UnexpectedRowCount (rowToInt maxRows)))
-  where
-    rowToInt (Pq.Row n) =
-      fromIntegral n
+{-# INLINABLE decodeRow #-}
+decodeRow :: RowDecoder.RowDecoder a -> Pq.Result -> Pq.Row -> IO (Either Error a)
+decodeRow rowDec result row =
+  RowDecoder.toDecoder rowDec result row
+    <&> first (RowError (rowToInt row))
 
-{-# INLINE single #-}
-single :: RowDecoder.RowDecoder a -> ResultDecoder a
-single rowDec =
-  do
-    checkExecStatus [Pq.TuplesOk]
-    checkCompatibility rowDec
-    ResultDecoder
-      $ \result -> do
-        maxRows <- Pq.ntuples result
-        case maxRows of
-          1 -> do
-            RowDecoder.toDecoder rowDec result 0
-              <&> first (RowError 0)
-          _ -> return (Left (UnexpectedRowCount (rowToInt maxRows)))
-  where
-    rowToInt (Pq.Row n) =
-      fromIntegral n
+{-# INLINE rowToInt #-}
+rowToInt :: Pq.Row -> Int
+rowToInt (Pq.Row n) = fromIntegral n
 
-{-# INLINE vector #-}
-vector :: RowDecoder.RowDecoder a -> ResultDecoder (Vector a)
-vector rowDec =
-  do
-    checkExecStatus [Pq.TuplesOk]
-    checkCompatibility rowDec
-    ResultDecoder
-      $ \result -> do
-        maxRows <- Pq.ntuples result
-        mvector <- MutableVector.unsafeNew (rowToInt maxRows)
-        failureRef <- newIORef Nothing
-        forMFromZero_ (rowToInt maxRows) $ \rowIndex -> do
-          rowResult <- RowDecoder.toDecoder rowDec result (intToRow rowIndex)
-          case rowResult of
-            Left !err -> writeIORef failureRef (Just (RowError rowIndex err))
-            Right !x -> MutableVector.unsafeWrite mvector rowIndex x
-        readIORef failureRef >>= \case
-          Nothing -> Right <$> Vector.unsafeFreeze mvector
-          Just x -> pure (Left x)
-  where
-    rowToInt (Pq.Row n) =
-      fromIntegral n
-    intToRow =
-      Pq.Row . fromIntegral
-
-{-# INLINE foldl #-}
-foldl :: (a -> b -> a) -> a -> RowDecoder.RowDecoder b -> ResultDecoder a
-foldl step init rowDec =
-  {-# SCC "foldl" #-}
-  do
-    checkExecStatus [Pq.TuplesOk]
-    checkCompatibility rowDec
-    ResultDecoder
-      $ \result ->
-        {-# SCC "traversal" #-}
-        do
-          maxRows <- Pq.ntuples result
-          accRef <- newIORef init
-          failureRef <- newIORef Nothing
-          forMFromZero_ (rowToInt maxRows) $ \rowIndex -> do
-            rowResult <- RowDecoder.toDecoder rowDec result (intToRow rowIndex)
-            case rowResult of
-              Left !err -> writeIORef failureRef (Just (RowError rowIndex err))
-              Right !x -> modifyIORef' accRef (\acc -> step acc x)
-          readIORef failureRef >>= \case
-            Nothing -> Right <$> readIORef accRef
-            Just x -> pure (Left x)
-  where
-    rowToInt (Pq.Row n) =
-      fromIntegral n
-    intToRow =
-      Pq.Row . fromIntegral
-
-{-# INLINE foldr #-}
-foldr :: (b -> a -> a) -> a -> RowDecoder.RowDecoder b -> ResultDecoder a
-foldr step init rowDec =
-  {-# SCC "foldr" #-}
-  do
-    checkExecStatus [Pq.TuplesOk]
-    checkCompatibility rowDec
-    ResultDecoder
-      $ \result -> do
-        maxRows <- Pq.ntuples result
-        accRef <- newIORef init
-        failureRef <- newIORef Nothing
-        forMToZero_ (rowToInt maxRows) $ \rowIndex -> do
-          rowResult <- RowDecoder.toDecoder rowDec result (intToRow rowIndex)
-          case rowResult of
-            Left !err -> writeIORef failureRef (Just (RowError rowIndex err))
-            Right !x -> modifyIORef accRef (\acc -> step x acc)
-        readIORef failureRef >>= \case
-          Nothing -> Right <$> readIORef accRef
-          Just x -> pure (Left x)
-  where
-    rowToInt (Pq.Row n) =
-      fromIntegral n
-    intToRow =
-      Pq.Row . fromIntegral
-
--- * Refinement
-
-refine :: (a -> Either Text b) -> ResultDecoder a -> ResultDecoder b
-refine refiner (ResultDecoder reader) = ResultDecoder
-  $ \result -> do
-    resultEither <- reader result
-    return $ resultEither >>= first UnexpectedResult . refiner
+{-# INLINE intToRow #-}
+intToRow :: Int -> Pq.Row
+intToRow = Pq.Row . fromIntegral
 
 -- * Errors
 

--- a/src/library/Hasql/Comms/RowReader.hs
+++ b/src/library/Hasql/Comms/RowReader.hs
@@ -32,62 +32,84 @@ data CellError
   | UnexpectedNullCellError
   deriving stock (Eq, Show)
 
+-- | Outcome of running a 'RowReader' starting from a given column: either it
+-- failed, or it produced a value along with the column position to resume
+-- decoding from.
+data Outcome a
+  = Failure Error
+  | Success a Pq.Column
+
+-- | A row reader is a closure threading the current column position
+-- explicitly through its arguments and return value, instead of through a
+-- monad transformer stack. Composing readers with '(<*>)' therefore costs
+-- nothing beyond the direct 'IO' calls each one performs.
 newtype RowReader a
-  = RowReader (StateT Pq.Column (ReaderT Env (ExceptT Error IO)) a)
-  deriving
-    (Functor, Applicative)
-    via (StateT Pq.Column (ReaderT Env (ExceptT Error IO)))
+  = RowReader (Pq.Result -> Pq.Row -> Pq.Column -> IO (Outcome a))
 
-data Env
-  = Env
-      Pq.Result
-      Pq.Row
+instance Functor RowReader where
+  {-# INLINE fmap #-}
+  fmap f (RowReader run) = RowReader \result row col -> do
+    outcome <- run result row col
+    pure case outcome of
+      Failure err -> Failure err
+      Success a col' -> Success (f a) col'
 
--- * Instances
+instance Applicative RowReader where
+  {-# INLINE pure #-}
+  pure a = RowReader \_ _ col -> pure (Success a col)
+  {-# INLINE (<*>) #-}
+  RowReader runF <*> RowReader runA = RowReader \result row col -> do
+    outcomeF <- runF result row col
+    case outcomeF of
+      Failure err -> pure (Failure err)
+      Success f col' -> do
+        outcomeA <- runA result row col'
+        pure case outcomeA of
+          Failure err -> Failure err
+          Success a col'' -> Success (f a) col''
 
 instance Filterable RowReader where
   {-# INLINE mapMaybe #-}
-  mapMaybe fn (RowReader run) =
-    RowReader do
-      result <- run
-      case fn result of
-        Just refined -> pure refined
-        Nothing -> throwError (RefinementError "Filtration failed")
+  mapMaybe fn (RowReader run) = RowReader \result row col -> do
+    outcome <- run result row col
+    pure case outcome of
+      Failure err -> Failure err
+      Success a col' -> case fn a of
+        Just refined -> Success refined col'
+        Nothing -> Failure (RefinementError "Filtration failed")
 
 -- * Functions
 
 {-# INLINE toHandler #-}
 toHandler :: RowReader a -> Pq.Result -> Pq.Row -> IO (Either Error a)
-toHandler (RowReader f) result row =
-  let env = Env result row
-   in runExceptT (runReaderT (evalStateT f 0) env)
+toHandler (RowReader run) result row = do
+  outcome <- run result row 0
+  pure case outcome of
+    Failure err -> Left err
+    Success a _ -> Right a
 
 -- |
 -- Next value, decoded using the provided value decoder.
 {-# INLINE column #-}
 column :: (Maybe a -> Maybe b) -> (ByteString -> Either Text a) -> RowReader b
-column processNullable valueDec = RowReader do
-  col <- get
-  Env result row <- ask
-  let colInt = Pq.colToInt col
-  put (succ col)
+column processNullable valueDec = RowReader \result row col -> do
+  rawMaybe <- {-# SCC "getvalue'" #-} Pq.getvalue' result row col
 
-  valueMaybe <- liftIO ({-# SCC "getvalue'" #-} Pq.getvalue' result row col)
+  decodedMaybe <- case rawMaybe of
+    Nothing -> pure (Right Nothing)
+    Just v -> case {-# SCC "decode" #-} valueDec v of
+      Left err -> do
+        oid <- Pq.oidToWord32 <$> Pq.ftype result col
+        pure (Left (CellError (Pq.colToInt col) oid (DecodingCellError err)))
+      Right decoded -> pure (Right (Just decoded))
 
-  valueMaybe <- case valueMaybe of
-    Nothing -> pure Nothing
-    Just v ->
-      case {-# SCC "decode" #-} valueDec v of
-        Left err -> do
-          oid <- Pq.oidToWord32 <$> liftIO (Pq.ftype result col)
-          throwError (CellError colInt oid (DecodingCellError err))
-        Right decoded -> pure (Just decoded)
-
-  case processNullable valueMaybe of
-    Nothing -> do
-      oid <- Pq.oidToWord32 <$> liftIO (Pq.ftype result col)
-      throwError (CellError colInt oid UnexpectedNullCellError)
-    Just decoded -> pure decoded
+  case decodedMaybe of
+    Left err -> pure (Failure err)
+    Right valueMaybe -> case processNullable valueMaybe of
+      Nothing -> do
+        oid <- Pq.oidToWord32 <$> Pq.ftype result col
+        pure (Failure (CellError (Pq.colToInt col) oid UnexpectedNullCellError))
+      Just decoded -> pure (Success decoded (succ col))
 
 -- |
 -- Next value, decoded using the provided value decoder.

--- a/src/library/Hasql/Engine/Decoders/Result.hs
+++ b/src/library/Hasql/Engine/Decoders/Result.hs
@@ -11,7 +11,7 @@ import Hasql.Platform.Prelude
 newtype Result a
   = Result (RequestingOid.RequestingOid (ResultDecoder.ResultDecoder a))
   deriving
-    (Functor, Applicative, Filterable)
+    (Functor, Filterable)
     via (Compose RequestingOid.RequestingOid ResultDecoder.ResultDecoder)
 
 unwrap :: Result a -> RequestingOid.RequestingOid (ResultDecoder.ResultDecoder a)


### PR DESCRIPTION
## Summary

Implements #312. Replaces `Hasql.Comms.ResultDecoder` and `Hasql.Comms.RowReader`'s `ReaderT`/`ExceptT`/`StateT`-composed implementations with defunctionalized, closure-based interpreters, mirroring the `HasqlDriver.consumeResult` decode-loop redesign found on the `pqi/native` branch's `hasql-driver` package — mechanically adapted to master's existing `Hasql.Pq` connection layer, **without** pulling in the pqi record-of-functions connection abstraction.

- `Hasql.Comms.RowReader`: dropped its `StateT Pq.Column (ReaderT Env (ExceptT Error IO))` stack for a plain closure `Pq.Result -> Pq.Row -> Pq.Column -> IO (Outcome a)` that threads the column position explicitly.
- `Hasql.Comms.ResultDecoder`: became a thin `newtype` over a GADT `Plan a` (one constructor per result shape — `checkExecStatus`, `rowsAffected`, `maybe`, `single`, `vector`, `foldl`, `foldr`, `refine`, ...), interpreted by a single `INLINABLE` `runPlan` instead of running generic `Applicative`/`Monad` machinery at every accessor call.
- `Hasql.Engine.Decoders.Result`: dropped the now-unused `Applicative` from its `deriving via` clause (confirmed no call site relied on it).

Public API surface is unchanged — `ResultDecoder`/`RowDecoder`'s external types and function signatures are byte-identical, so all downstream modules compile without edits beyond the one `deriving via` line.

## Benchmark results (local Postgres, Apple Silicon, noisy shared machine — see caveats)

Two runs each, `cabal bench bench:benchmarks`:

| Benchmark | Baseline (master) | After (this branch) |
|---|---|---|
| largeResultInVector | ~2.01–2.05 ms | ~1.89–1.94 ms (consistently faster) |
| largeResultInList | ~2.03–2.68 ms | ~1.94–2.06 ms (flat-to-faster) |
| manyLargeResults | ~316–355 ms | ~355–469 ms (R² as low as 0.27–0.54 — dominated by machine noise, no reliable signal) |
| manyLargeResultsViaPipeline | ~299–315 ms | ~299–335 ms (flat, within noise) |
| manySmallResults | ~2.94–3.63 ms | ~2.94–4.30 ms (noisy both directions, no reliable signal) |
| manySmallResultsViaPipeline | ~1.43–1.50 ms | ~1.34–1.44 ms (slightly faster) |

The single-result decode path (`largeResultInVector`/`largeResultInList`, exercising `single`/`vector` through `runPlan` directly) shows a modest, repeatable win. The multi-result/pipeline benchmarks are dominated by per-run variance on this machine (consistent with the `76–98%` "severely inflated" variance already noted in prior migration-to-pqi benchmark dumps) and don't show a clear signal in either direction — no regression, but also not conclusive evidence of a win at that granularity. Recommend re-running on a quieter/dedicated machine before using these numbers to make a merge decision.

## Test plan

- [x] `cabal build lib:hasql` — succeeds
- [x] `cabal build all --enable-tests --enable-benchmarks` — succeeds (library, all test suites, benchmarks, profiling executable)
- [x] `cabal test library-tests --enable-tests --test-options='--match "Pure"'` — 37 examples, 0 failures
- [x] `cabal test engine-tests --enable-tests` — 27 examples, 0 failures
- [x] `cabal test comms-tests --enable-tests` — 14 examples, 0 failures (postgres:9 and postgres:18 via testcontainers)
- [x] `cabal test library-tests --enable-tests` (full suite, DB-backed) — 528 examples, 0 failures
- [x] `ormolu --mode inplace` — applied, no functional changes
- [x] `hlint` — 4 hints, all pre-existing patterns also present in master's current file (verified by running hlint against master's version)